### PR TITLE
Save response in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,12 @@ class PokeAPIGlobalTester(GlobalTester):
 #### Create endpoint's specifications
 You can create a YAML file with the same name and location of your mapping file to use some specification with tests.
 ```yaml
-extended_path:  # extend path for your API's url
+save_response: yes  # save API's response in tests results
+extended_path:      # extend path for your API's url
     - '/charizard'
     - '/bulbasaur'
 
-query_specs:  # kwargs for request library (get)
+query_specs:        # kwargs for request library (get)
     headers:
         token: 'mon_token'
 ```

--- a/data/mapping/pokeapi/pokemon.yaml
+++ b/data/mapping/pokeapi/pokemon.yaml
@@ -1,3 +1,4 @@
+save_response: yes
 extended_paths:
     - '/charizard'
     - '/bulbasaur'

--- a/models/global_tester.py
+++ b/models/global_tester.py
@@ -24,6 +24,7 @@ class GlobalTester:
         for file in os.listdir('{}/data/mapping/{}'.format(os.getcwd(), self.service.path)):
             if file.endswith('.json'):
                 extended_paths = ['']
+                save_response = False
                 query_specs = {'headers': self.service.headers}
                 if os.path.isfile('{}/data/mapping/{}/{}'.format(os.getcwd(), self.service.path, file[:-4] + 'yaml')):
                     with open('{}/data/mapping/{}/{}'.format(os.getcwd(), self.service.path, file[:-4] + 'yaml'), 'r') as yaml_file:

--- a/models/tester.py
+++ b/models/tester.py
@@ -1,15 +1,21 @@
 import os
+import json
 from models.service import Service
 from utils.request_api import api_get_json
 from utils.mapping import is_mapping_ok
 
 
-def apitester(env: str, service: Service, extended_path: str, **specifications):
+def apitester(env: str, service: Service, extended_path: str, **specifications) -> tuple[str, list]:
     response = api_get_json(
         service.url(env, specifications['api']) + extended_path,
         **specifications['query_specs']
     )
 
+    if specifications['save_response']:
+        resp_to_save = json.dumps(response, ensure_ascii=True)
+    else:
+        resp_to_save = None
+
     errors = is_mapping_ok(response, '{}/data/mapping/{}'.format(os.getcwd(), service.path + specifications['filename']))
 
-    return errors
+    return resp_to_save, errors

--- a/tests/test_models/test_global_tester.py
+++ b/tests/test_models/test_global_tester.py
@@ -18,9 +18,9 @@ class MockedService:
 class TestGlobalTester(unittest.TestCase):
     @patch('models.global_tester.apitester', return_value=list())
     @patch('models.global_tester.Service', side_effect=MockedService)
-    @patch('os.listdir', return_value=['test_api.json'])
-    @patch('yaml.load', return_value=dict(extended_paths=['/extra']))
-    @patch('utils.mongodb.MongoCon.save_results')
+    @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
+    @patch('models.global_tester.yaml.load', return_value=dict(extended_paths=['/extra']))
+    @patch('models.global_tester.MongoCon.save_results')
     def test_test_executer_success(self, mockpatch_apitester, mockpatch_service, mockpatch_listdir, mockpatch_load, mockpatch_save_results):
         tester = GlobalTester('production', 'TestService')
         print(tester.tests[0])
@@ -36,9 +36,9 @@ class TestGlobalTester(unittest.TestCase):
 
     @patch('models.global_tester.apitester', return_value=['fake_error_object'])
     @patch('models.global_tester.Service', side_effect=MockedService)
-    @patch('os.listdir', return_value=['test_api.json'])
-    @patch('yaml.load', return_value=dict(extended_paths=['/extra']))
-    @patch('utils.mongodb.MongoCon.save_results')
+    @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
+    @patch('models.global_tester.yaml.load', return_value=dict(extended_paths=['/extra']))
+    @patch('models.global_tester.MongoCon.save_results')
     def test_test_executer_failure(self, mockpatch_apitester, mockpatch_service, mockpatch_listdir, mockpatch_load, mockpatch_save_results):
         tester = GlobalTester('production', 'TestService')
         assert len(tester.tests) == 1

--- a/tests/test_models/test_global_tester.py
+++ b/tests/test_models/test_global_tester.py
@@ -16,7 +16,7 @@ class MockedService:
 
 
 class TestGlobalTester(unittest.TestCase):
-    @patch('models.global_tester.apitester', return_value=list())
+    @patch('models.global_tester.apitester', return_value=(None, list()))
     @patch('models.global_tester.Service', side_effect=MockedService)
     @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
     @patch('models.global_tester.yaml.load', return_value=dict(extended_paths=['/extra']))
@@ -34,7 +34,7 @@ class TestGlobalTester(unittest.TestCase):
         assert len(tester.tests[0]['errors']) == 0
         mockpatch_save_results.assert_called_once()
 
-    @patch('models.global_tester.apitester', return_value=['fake_error_object'])
+    @patch('models.global_tester.apitester', return_value=(None, ['fake_error_object']))
     @patch('models.global_tester.Service', side_effect=MockedService)
     @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
     @patch('models.global_tester.yaml.load', return_value=dict(extended_paths=['/extra']))

--- a/tests/test_models/test_tester.py
+++ b/tests/test_models/test_tester.py
@@ -8,8 +8,18 @@ class TestTester(unittest.TestCase):
     @patch.multiple('models.tester',
                     api_get_json=MagicMock(return_value=dict(metadata=dict(request_id=1234))),
                     is_mapping_ok=MagicMock(return_value=['error']))
-    def test_tester(self):
-        result = apitester('production', Service('pokeapi'), '', api='test', query_specs=dict(), filename="item.json")
+    def test_tester_save_response_false(self):
+        response, result = apitester('production', Service('pokeapi'), '', api='test', query_specs=dict(), save_response=False, filename="item.json")
+        assert response is None
+        assert len(result) == 1
+        assert result[0] == 'error'
+
+    @patch.multiple('models.tester',
+                    api_get_json=MagicMock(return_value=dict(metadata=dict(request_id=1234))),
+                    is_mapping_ok=MagicMock(return_value=['error']))
+    def test_tester_save_response_true(self):
+        response, result = apitester('production', Service('pokeapi'), '', api='test', query_specs=dict(), save_response=True, filename="item.json")
+        assert response == '{"metadata": {"request_id": 1234}}'
         assert len(result) == 1
         assert result[0] == 'error'
 

--- a/utils/request_api.py
+++ b/utils/request_api.py
@@ -1,4 +1,4 @@
-from requests import get
+from requests import get, JSONDecodeError
 
 HEADERS = {
     "User-Agent": "test-mapping",
@@ -11,7 +11,8 @@ def api_get_json(*args, **kwargs):
         kwargs["headers"] = {}
     kwargs["headers"].update(HEADERS)
 
+    response = get(*args, **kwargs)
     try:
-        return get(*args, **kwargs).json()
-    except Exception as e:
+        return response.json()
+    except JSONDecodeError as e:
         raise e


### PR DESCRIPTION
Save APIs responses in tests results as the following schema:
```json
{
  "_id": {
    "$oid": "67a9c7c334e551c08843e81b"
  },
  "title": "Test on /pokemon/vulpix",
  "session_id": "250210-103250-25babca1",
  "env": "production",
  "service": "pokeapi",
  "request": "https://pokeapi.co/api/v2/pokemon/vulpix",
  "headers": {
    "User-Agent": "test-mapping",
    "referer": "test-mapping"
  },
  "params": {},
  "status": true,
  "errors": [],
  "api_response": "{\"test\": 1234}",
  "timestamp": 1739179971
}
```

`api_response` can be a `string` or `null`