### PR TITLE
Return complete url in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Your test results are stored as documents in the following format:
   },
   "service": "pokeapi",
   "env": "production",
-  "request": "https://pokeapi.co/api/v2/item/master-ball",
+  "url": "https://pokeapi.co/api/v2/item/master-ball",
   "status": true,
   "errors": [],
   "api_response": null,

--- a/models/global_tester.py
+++ b/models/global_tester.py
@@ -54,7 +54,7 @@ class GlobalTester:
                 ),
                 service=self.service.name,
                 env=self.env,
-                request=self.service.url(self.env, specifications['api']) + extended_path,
+                url=self.service.url(self.env, specifications['api'], extended_path, **specifications['query_specs']['params'] if 'params' in specifications['query_specs'].keys() else {}),
                 headers={"User-Agent": "test-mapping", "referer": 'test-mapping', **specifications['query_specs']['headers']},
                 params=specifications['query_specs']['params'] if 'params' in specifications['query_specs'].keys() else {},
 

--- a/models/service.py
+++ b/models/service.py
@@ -17,9 +17,15 @@ class Service:
     def options(self) -> dict:
         return self.service['options'] if 'options' in self.service.keys() else {}
 
-    def url(self, env: str, api: str) -> str:
+    def url(self, env: str, api: str, extended_path: str = None, **kwargs) -> str:
+        if not extended_path:
+            extended_path = ''
+        url = self.service['uri'].format(url=self.service['url'][env], api=api) + extended_path
+        if kwargs:
+            url += '/?' + '&'.join([f'{key}={value}' for key, value in kwargs.items()])
+
         if self.service['url'][env]:
-            return self.service['uri'].format(url=self.service['url'][env], api=api)
+            return url
         else:
             raise Exception(f"no url defined for {env}")
 

--- a/tests/test_models/test_global_tester.py
+++ b/tests/test_models/test_global_tester.py
@@ -11,7 +11,7 @@ class MockedService:
     def __init__(self, name: str):
         self.name = name
 
-    def url(self, env, api):
+    def url(self, env, api, extended_path, **kwargs):
         return 'http://example.com'
 
 
@@ -29,7 +29,6 @@ class TestGlobalTester(unittest.TestCase):
         assert tester.tests[0]['test_info']['title'] == 'Test on /test_api/extra'
         assert tester.tests[0]['service'] == 'TestService'
         assert tester.tests[0]['env'] == 'production'
-        assert tester.tests[0]['request'] == 'http://example.com/extra'
         print(tester.tests[0]['headers'])
         assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value', 'test': 123}
         assert tester.tests[0]['params'] == {'test': 1}
@@ -50,7 +49,6 @@ class TestGlobalTester(unittest.TestCase):
         assert tester.tests[0]['test_info']['title'] == 'Test on /test_api/extra'
         assert tester.tests[0]['service'] == 'TestService'
         assert tester.tests[0]['env'] == 'production'
-        assert tester.tests[0]['request'] == 'http://example.com/extra'
         assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value'}
         assert tester.tests[0]['params'] == {}
         assert not tester.tests[0]['status']

--- a/tests/test_models/test_service.py
+++ b/tests/test_models/test_service.py
@@ -8,7 +8,7 @@ class TestService(unittest.TestCase):
         assert service.name == 'pokeapi'
         assert service.path == '/pokeapi/'
         assert service.options == dict(request_delay=100)
-        assert service.url('production', 'test') == "https://pokeapi.co/api/v2/test"
+        assert service.url('production', 'test', '/extra_path', param1=2, param2=1) == "https://pokeapi.co/api/v2/test/extra_path/?param1=2&param2=1"
         assert service.headers == dict()
 
         assert service.service == dict(


### PR DESCRIPTION
Service.url() will now return the full request URL:
```
https://pokeapi.co/api/v2/pokemon/vulpix/?test=12
```