### PR TITLE
Secret prefix in headers nor params

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,13 @@ extended_path:      # extend path for your API's url
     - '/bulbasaur'
 query_specs:        # kwargs for request library (get)
     headers:
-        token: 'mon_token'
+        token: '$secret:mon_token'
     params:
         id: 2
 ```
 Each path attribute are optional, even the YAML file itself!
+
+If you have credentials you don't want saved in the database, prefix any headers or parameters value with `$secret:`.
 
 ### Run API Tests
 Import the `shortcut` file and call your child class:

--- a/models/global_tester.py
+++ b/models/global_tester.py
@@ -2,10 +2,10 @@ import os
 import yaml
 from time import sleep
 from datetime import datetime
-from utils.commons import generate_session_id
 from utils.mongodb import MongoCon
 from models.tester import apitester
 from models.service import Service
+from utils.commons import generate_session_id, query_specs_secret
 
 
 class GlobalTester:
@@ -46,6 +46,8 @@ class GlobalTester:
         print("\nYour session ID: " + self.session_id)
 
     def test_executer(self, **specifications):
+        specifications['query_specs'], query_specs_hidden = query_specs_secret(specifications['query_specs'])
+
         for extended_path in specifications['extended_paths']:
             response, errors = apitester(self.env, self.service, extended_path, **specifications)
 
@@ -59,8 +61,8 @@ class GlobalTester:
                 service=self.service.name,
                 env=self.env,
                 url=self.service.url(self.env, specifications['api'], extended_path, **specifications['query_specs']['params'] if 'params' in specifications['query_specs'].keys() else {}),
-                headers={"User-Agent": "test-mapping", "referer": 'test-mapping', **specifications['query_specs']['headers']},
-                params=specifications['query_specs']['params'] if 'params' in specifications['query_specs'].keys() else {},
+                headers={"User-Agent": "test-mapping", "referer": 'test-mapping', **query_specs_hidden['headers']},
+                params=query_specs_hidden['params'] if 'params' in query_specs_hidden.keys() else {},
 
                 status=False if errors else True,
                 errors=[error.__str__() for error in errors],

--- a/tests/test_models/test_global_tester.py
+++ b/tests/test_models/test_global_tester.py
@@ -19,10 +19,51 @@ class TestGlobalTester(unittest.TestCase):
     @patch('models.global_tester.apitester', return_value=(None, list()))
     @patch('models.global_tester.Service', side_effect=MockedService)
     @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
-    @patch('models.global_tester.os.path.isfile', return_value=True)
-    @patch('models.global_tester.open', new=mock_open(read_data='extended_paths:\n- /extra\nquery_specs:\n  headers:\n    test: 123\n  params:\n    test: 1\n'))
+    @patch('models.global_tester.os.path.isfile', return_value=False)
     @patch('models.global_tester.MongoCon')
     def test_test_executer_success(self, mockpatch_apitester, mockpatch_service, mockpatch_listdir, mockpatch_isfile, mockpatch_save_results):
+        tester = GlobalTester('production', 'TestService')
+        assert len(tester.tests) == 1
+        assert tester.tests[0]['test_info']['title'] == 'Test on /test_api'
+        assert tester.tests[0]['service'] == 'TestService'
+        assert tester.tests[0]['env'] == 'production'
+        assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value'}
+        assert tester.tests[0]['params'] == {}
+        assert tester.tests[0]['status']
+        assert len(tester.tests[0]['errors']) == 0
+        assert tester.tests[0]['api_response'] is None
+        mockpatch_save_results.assert_called_once()
+
+    @patch('models.global_tester.apitester', return_value=(None, list()))
+    @patch('models.global_tester.Service', side_effect=MockedService)
+    @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
+    @patch('models.global_tester.os.path.isfile', return_value=True)
+    @patch('models.global_tester.open', new=mock_open(read_data='extended_paths:\n- /extra\n- /extra2'))
+    @patch('models.global_tester.MongoCon')
+    def test_test_executer_success_extended_path(self, mockpatch_apitester, mockpatch_service, mockpatch_listdir, mockpatch_isfile, mockpatch_save_results):
+        tester = GlobalTester('production', 'TestService')
+        print(tester.tests[0])
+        assert len(tester.tests) == 2
+        assert tester.tests[0]['test_info']['title'] == 'Test on /test_api/extra'
+        assert tester.tests[0]['service'] == 'TestService'
+        assert tester.tests[0]['env'] == 'production'
+        print(tester.tests[0]['headers'])
+        assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value'}
+        assert tester.tests[0]['params'] == {}
+        assert tester.tests[0]['status']
+        assert len(tester.tests[0]['errors']) == 0
+        assert tester.tests[0]['api_response'] is None
+        mockpatch_save_results.assert_called()
+
+    @patch('models.global_tester.apitester', return_value=(None, list()))
+    @patch('models.global_tester.Service', side_effect=MockedService)
+    @patch('models.global_tester.os.listdir', return_value=['test_api.json'])
+    @patch('models.global_tester.os.path.isfile', return_value=True)
+    @patch('models.global_tester.open', new=mock_open(
+        read_data='extended_paths:\n- /extra\nquery_specs:\n  headers:\n    test: 123\n    secret: $secret:test\n  params:\n    test: 1\n'
+    ))
+    @patch('models.global_tester.MongoCon')
+    def test_test_executer_query_specs(self, mockpatch_apitester, mockpatch_service, mockpatch_listdir, mockpatch_isfile, mockpatch_save_results):
         tester = GlobalTester('production', 'TestService')
         print(tester.tests[0])
         assert len(tester.tests) == 1
@@ -30,7 +71,7 @@ class TestGlobalTester(unittest.TestCase):
         assert tester.tests[0]['service'] == 'TestService'
         assert tester.tests[0]['env'] == 'production'
         print(tester.tests[0]['headers'])
-        assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value', 'test': 123}
+        assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value', 'test': 123, 'secret': '****************'}
         assert tester.tests[0]['params'] == {'test': 1}
         assert tester.tests[0]['status']
         assert len(tester.tests[0]['errors']) == 0
@@ -55,7 +96,6 @@ class TestGlobalTester(unittest.TestCase):
         assert len(tester.tests[0]['errors']) == 1
         assert tester.tests[0]['api_response'] is None
         mockpatch_save_results.assert_called_once()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_models/test_global_tester.py
+++ b/tests/test_models/test_global_tester.py
@@ -47,7 +47,6 @@ class TestGlobalTester(unittest.TestCase):
         assert tester.tests[0]['test_info']['title'] == 'Test on /test_api/extra'
         assert tester.tests[0]['service'] == 'TestService'
         assert tester.tests[0]['env'] == 'production'
-        print(tester.tests[0]['headers'])
         assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value'}
         assert tester.tests[0]['params'] == {}
         assert tester.tests[0]['status']
@@ -70,7 +69,6 @@ class TestGlobalTester(unittest.TestCase):
         assert tester.tests[0]['test_info']['title'] == 'Test on /test_api/extra'
         assert tester.tests[0]['service'] == 'TestService'
         assert tester.tests[0]['env'] == 'production'
-        print(tester.tests[0]['headers'])
         assert tester.tests[0]['headers'] == {'User-Agent': 'test-mapping', 'referer': 'test-mapping', 'key': 'value', 'test': 123, 'secret': '****************'}
         assert tester.tests[0]['params'] == {'test': 1}
         assert tester.tests[0]['status']

--- a/tests/test_utils/test_commons.py
+++ b/tests/test_utils/test_commons.py
@@ -1,5 +1,5 @@
 import unittest
-from utils.commons import get_value, generate_session_id
+from utils.commons import get_value, generate_session_id, query_specs_secret
 
 
 class TestCommons(unittest.TestCase):
@@ -14,6 +14,18 @@ class TestCommons(unittest.TestCase):
         assert session_id[:6].isdigit()
         assert session_id[7:13].isdigit()
         assert session_id != generate_session_id()
+
+    def test_query_specs_secret(self):
+        value, hidden_value = query_specs_secret(dict(
+            headers={'secret': '$secret:my_secret', 'user': 'asauvage'},
+            params={'id': 2, 'secret_id': '$secret:23'}
+        ))
+        assert value['headers']['secret'] == 'my_secret'
+        assert hidden_value['headers']['secret'] == '****************'
+        assert hidden_value['headers']['user'] == 'asauvage'
+        assert hidden_value['params']['id'] == 2
+        assert value['params']['secret_id'] == '23'
+        assert hidden_value['params']['secret_id'] == '****************'
 
 
 if __name__ == '__main__':

--- a/utils/commons.py
+++ b/utils/commons.py
@@ -2,6 +2,7 @@ import json
 from uuid import uuid4
 from datetime import datetime
 from functools import reduce
+from copy import deepcopy
 
 
 def get_value(data: dict, keys: list):
@@ -11,6 +12,19 @@ def get_value(data: dict, keys: list):
 def get_mapping_ref(mapping: dict, ref_path: str, ref: str):
     with open(f"{ref_path}/generics/{ref}.json") as json_file:
         return mapping | json.load(json_file)
+
+
+def query_specs_secret(query_specs: dict) -> tuple[dict, dict]:
+    query_specs_hidden = deepcopy(query_specs)
+
+    for spec_name, spec_value in query_specs.items():
+        for key, value in spec_value.items():
+            value = str(value)
+            if value.startswith("$secret:"):
+                query_specs[spec_name][key] = value[8:]
+                query_specs_hidden[spec_name][key] = "****************"
+
+    return query_specs, query_specs_hidden
 
 
 # 230918-203654-545d6291

--- a/utils/commons.py
+++ b/utils/commons.py
@@ -19,10 +19,12 @@ def query_specs_secret(query_specs: dict) -> tuple[dict, dict]:
 
     for spec_name, spec_value in query_specs.items():
         for key, value in spec_value.items():
-            value = str(value)
-            if value.startswith("$secret:"):
-                query_specs[spec_name][key] = value[8:]
-                query_specs_hidden[spec_name][key] = "****************"
+            try:
+                if value.startswith("$secret:"):
+                    query_specs[spec_name][key] = value[8:]
+                    query_specs_hidden[spec_name][key] = "****************"
+            except AttributeError:
+                pass
 
     return query_specs, query_specs_hidden
 


### PR DESCRIPTION
Hide headers/params values using `$secret:` prefix:
```yaml
query_specs:        # kwargs for request library (get)
    headers:
        token: '$secret:mon_token'
    params:
        id: 2
```